### PR TITLE
add tarp counts

### DIFF
--- a/farmapp.py
+++ b/farmapp.py
@@ -293,10 +293,15 @@ def folien_view():
     df_folien = df_folien.loc[df_folien['EndDate'] == '']
     df_folien["Tage drauf"] = ((datetime.today() - pd.to_datetime(df_folien['StartDate'], format='%Y-%m-%d')).dt.days)
     df_folien = df_folien.drop(['EndDate'], axis=1)
+    # make index match count
+    df_folien= df_folien.reset_index(drop=True)
+    # Get number of rows/tarps
+    num_tarps = df_folien.shape[0]
     return render_template(
         'folien_history.html',
         tables=[df_folien.to_html(classes=['tablestyle', 'sortable'], header="true")],
         h1_string="Seit wann liegen schwarze Folien?",
+        num_tarps = num_tarps,
         update_date = str(get_most_recent_update_date())
     )
 

--- a/static/styles/df_style.css
+++ b/static/styles/df_style.css
@@ -25,6 +25,15 @@ p {
   font-style: italic;
 }
 
+.center-bold {
+  text-align: center;
+  margin-top: 20px;
+  margin-bottom: 20px;
+  margin-right: 20px;
+  margin-left: 20px;
+  font-style: bold;
+}
+
   /* Make width responsive (horizontal sliding bar)  */
 .table-wrapper {
     width: 100%;

--- a/templates/folien_history.html
+++ b/templates/folien_history.html
@@ -8,6 +8,7 @@
 <link rel="stylesheet" type="text/css" href= "{{ url_for('static',filename='styles/df_style.css') }}">
 <body>
     <h1>{{ h1_string }}</h1>
+    <p class="center-bold">Verwendete Folien = {{num_tarps}}</p>
     <div class="table-wrapper">
 {% for table in tables %}
             {{ table|safe }}


### PR DESCRIPTION
Adds tarp count and fixes numbering in the table to be accurate (starting at 0). No comparison to number of total tarps since the number keeps changing and thus is ultimately irrelevant.

Closes #8.